### PR TITLE
KAN-22 Admin user creation feature implemented

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,7 @@
 PORT =
 MONGO_URL = 
+
+# Default Admin user credentials
+ADMIN_USERNAME=
+ADMIN_EMAIL=
+ADMIN_PASSWORD=

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@nestjs/testing':
         specifier: ^10.0.0
         version: 10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4))
+      '@types/bcrypt':
+        specifier: ^5.0.2
+        version: 5.0.2
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.21
@@ -822,6 +825,9 @@ packages:
 
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
+
+  '@types/bcrypt@5.0.2':
+    resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -4276,6 +4282,10 @@ snapshots:
   '@types/babel__traverse@7.20.6':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@types/bcrypt@5.0.2':
+    dependencies:
+      '@types/node': 20.16.5
 
   '@types/body-parser@1.19.5':
     dependencies:

--- a/src/admin-users/admin-users.module.ts
+++ b/src/admin-users/admin-users.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AdminUsersResolver } from './admin-users.resolver';
+import { AdminUsersService } from './admin-users.service';
+import { AdminUser, AdminUserSchema } from './entities/admin-user.entity';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: AdminUser.name, schema: AdminUserSchema },
+    ]),
+  ],
+  providers: [AdminUsersResolver, AdminUsersService],
+})
+export class AdminUsersModule {}

--- a/src/admin-users/admin-users.resolver.spec.ts
+++ b/src/admin-users/admin-users.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminUsersResolver } from './admin-users.resolver';
+import { AdminUsersService } from './admin-users.service';
+
+describe('AdminUsersResolver', () => {
+  let resolver: AdminUsersResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminUsersResolver, AdminUsersService],
+    }).compile();
+
+    resolver = module.get<AdminUsersResolver>(AdminUsersResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/src/admin-users/admin-users.resolver.ts
+++ b/src/admin-users/admin-users.resolver.ts
@@ -1,0 +1,42 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { AdminUsersService } from './admin-users.service';
+import { CreateAdminUserInput } from './dto/create-admin-user.input';
+import { UpdateAdminUserInput } from './dto/update-admin-user.input';
+import { AdminUser } from './entities/admin-user.entity';
+
+@Resolver(() => AdminUser)
+export class AdminUsersResolver {
+  constructor(private readonly adminUsersService: AdminUsersService) {}
+
+  @Mutation(() => AdminUser)
+  createAdminUser(
+    @Args('createAdminUserInput') createAdminUserInput: CreateAdminUserInput,
+  ) {
+    return this.adminUsersService.create(createAdminUserInput);
+  }
+
+  @Query(() => [AdminUser], { name: 'adminUsers' })
+  findAll() {
+    return this.adminUsersService.findAll();
+  }
+
+  @Query(() => AdminUser, { name: 'adminUser' })
+  findOne(@Args('id') id: string) {
+    return this.adminUsersService.get(id);
+  }
+
+  @Mutation(() => AdminUser)
+  updateAdminUser(
+    @Args('updateAdminUserInput') updateAdminUserInput: UpdateAdminUserInput,
+  ) {
+    return this.adminUsersService.update(
+      updateAdminUserInput.id,
+      updateAdminUserInput,
+    );
+  }
+
+  @Mutation(() => AdminUser)
+  removeAdminUser(@Args('id') id: string) {
+    return this.adminUsersService.remove(id);
+  }
+}

--- a/src/admin-users/admin-users.service.spec.ts
+++ b/src/admin-users/admin-users.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminUsersService } from './admin-users.service';
+
+describe('AdminUsersService', () => {
+  let service: AdminUsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminUsersService],
+    }).compile();
+
+    service = module.get<AdminUsersService>(AdminUsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/admin-users/admin-users.service.ts
+++ b/src/admin-users/admin-users.service.ts
@@ -1,0 +1,103 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateAdminUserInput } from './dto/create-admin-user.input';
+import { UpdateAdminUserInput } from './dto/update-admin-user.input';
+import {
+  AdminUser,
+  AdminUserDocument,
+  ROLE,
+} from './entities/admin-user.entity';
+
+@Injectable()
+export class AdminUsersService implements OnModuleInit {
+  constructor(
+    @InjectModel(AdminUser.name) private adminUserModel: Model<AdminUser>,
+    private configService: ConfigService,
+  ) {}
+
+  async onModuleInit() {
+    Logger.log('Initializing Admin User...');
+    await this.initializeAdminUser();
+  }
+
+  async create(createAdminUserInput: CreateAdminUserInput): Promise<AdminUser> {
+    Logger.log(
+      `Creating Admin User: ${createAdminUserInput.email}`,
+      'createAdminUser',
+    );
+    const isExist = await this.adminUserModel.countDocuments({
+      email: createAdminUserInput.email,
+    });
+
+    if (isExist > 0) {
+      throw new Error('Email already exists');
+    }
+
+    const user = await this.adminUserModel.create({
+      ...createAdminUserInput,
+    });
+
+    return { ...user?.toJSON(), password: undefined };
+  }
+
+  async initializeAdminUser() {
+    const adminUserCount = await this.adminUserModel.countDocuments({
+      role: ROLE.ADMIN,
+    });
+    Logger.log('Checking admin user count...', 'initializeAdmin');
+    if (adminUserCount > 0) {
+      Logger.log(
+        'Admin user already exists, so skip the default admin user creation',
+        'initializeAdmin',
+      );
+      return;
+    }
+    Logger.log('🚀 Creating default admin user...', 'initializeAdmin');
+    const adminUser = await this.create({
+      username: this.configService.get('ADMIN_USERNAME'),
+      email: this.configService.get('ADMIN_EMAIL'),
+      password: this.configService.get('ADMIN_PASSWORD'),
+      role: ROLE.ADMIN,
+      isActive: true,
+    });
+    Logger.log(
+      `✅ Default admin user created: ${adminUser.email}`,
+      'initializeAdmin',
+    );
+    return;
+  }
+
+  findAll(): Promise<AdminUser[]> {
+    return this.adminUserModel.find().select('-password');
+  }
+
+  async get(id: string): Promise<AdminUserDocument> {
+    const adminUser = await this.adminUserModel
+      .findById(id)
+      .select('-password');
+
+    if (!adminUser) {
+      throw new NotFoundException('Admin user not found');
+    }
+
+    return adminUser;
+  }
+
+  async update(id: string, updateAdminUserInput: UpdateAdminUserInput) {
+    const user = await this.get(id);
+    Object.assign(user, updateAdminUserInput);
+    await user.save();
+    return user;
+  }
+
+  remove(id: string) {
+    return this.adminUserModel.findByIdAndDelete(id);
+  }
+}

--- a/src/admin-users/dto/create-admin-user.input.ts
+++ b/src/admin-users/dto/create-admin-user.input.ts
@@ -1,0 +1,20 @@
+import { InputType, Int, Field } from '@nestjs/graphql';
+import { ROLE } from '../entities/admin-user.entity';
+
+@InputType()
+export class CreateAdminUserInput {
+  @Field()
+  username: string;
+
+  @Field()
+  email: string;
+
+  @Field()
+  password: string;
+
+  @Field(() => ROLE, { defaultValue: ROLE.USER }) // Default role is USER
+  role: ROLE;
+
+  @Field(() => Boolean, { defaultValue: true })
+  isActive: boolean;
+}

--- a/src/admin-users/dto/update-admin-user.input.ts
+++ b/src/admin-users/dto/update-admin-user.input.ts
@@ -1,0 +1,8 @@
+import { CreateAdminUserInput } from './create-admin-user.input';
+import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateAdminUserInput extends PartialType(CreateAdminUserInput) {
+  @Field()
+  id: string;
+}

--- a/src/admin-users/entities/admin-user.entity.ts
+++ b/src/admin-users/entities/admin-user.entity.ts
@@ -1,0 +1,56 @@
+import { ObjectType, Field, Int, registerEnumType } from '@nestjs/graphql';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import { hash } from 'src/utils';
+
+export enum ROLE {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
+
+registerEnumType(ROLE, {
+  name: 'ROLE',
+});
+
+@ObjectType()
+@Schema({ timestamps: true, collection: 'admin-users' })
+export class AdminUser {
+  @Field({ description: 'Username of the administrator' })
+  @Prop()
+  username: string;
+
+  @Field({ description: 'email of the administrator' })
+  @Prop({ unique: true })
+  email: string;
+
+  @Field({ description: 'password of the administrator' })
+  @Prop()
+  password: string;
+
+  @Field(() => Boolean, {
+    defaultValue: true,
+    description: 'User active status',
+  })
+  @Prop()
+  isActive: boolean;
+
+  @Field(() => ROLE, { description: 'User role', defaultValue: ROLE.ADMIN })
+  @Prop({ type: String, enum: ROLE, default: ROLE.ADMIN })
+  role: ROLE;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date;
+}
+
+export type AdminUserDocument = AdminUser & Document;
+export const AdminUserSchema = SchemaFactory.createForClass(AdminUser);
+
+AdminUserSchema.pre('save', function (next) {
+  if (this.isModified('password')) {
+    this.password = hash(this.password);
+  }
+  next();
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,11 +9,13 @@ import { UsersModule } from './users/users.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import configuration from './config/configuration';
 import { IAppConfig } from './interface/config';
+import { AdminUsersModule } from './admin-users/admin-users.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       load: [configuration],
+      isGlobal: true,
     }),
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
@@ -35,6 +37,7 @@ import { IAppConfig } from './interface/config';
       // },
     }),
     UsersModule,
+    AdminUsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
   app.useGlobalPipes(new ValidationPipe());
+
   await app.listen(process.env.PORT);
 }
 bootstrap();

--- a/src/utils/bcrypt.ts
+++ b/src/utils/bcrypt.ts
@@ -1,0 +1,5 @@
+import * as bcrypt from 'bcrypt';
+
+export function hash(input: string) {
+  return bcrypt.hashSync(input, 10);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './bcrypt';


### PR DESCRIPTION
feat: Implement Admin User CRUD functionality

- Created AdminUser model with fields: username, email, password, role, and isActive.
- Added DTOs for creating and updating admin users.
- Implemented AdminUsersService with methods for:
  - Creating a new admin user with email validation.
  - Retrieving all admin users (excluding passwords).
  - Fetching a specific admin user by ID.
  - Updating existing admin user details.
  - Deleting an admin user by ID.
- Integrated initialization method for default admin user creation.
- Configured Mongoose schema with timestamps and custom collection name.
- Updated GraphQL schema for AdminUser and CRUD operations.

Closes: KAN-22