### PR TITLE
fix: KAN-116 Remove redundant AdminAuthGuard from findAll query in UsersResolver and added in overall resolver

### DIFF
--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -7,7 +7,7 @@ import { CreateUserInput } from './dto/create-user.input';
 import { UpdateUserInput } from './dto/update-user.input';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
-
+@UseGuards(AdminAuthGuard)
 @Resolver(() => User)
 export class UsersResolver {
   constructor(private readonly usersService: UsersService, private readonly fileService: FilesService) { }
@@ -19,7 +19,6 @@ export class UsersResolver {
   }
 
   @Query(() => [User], { name: 'users' })
-  @UseGuards(AdminAuthGuard)
   findAll() {
     return this.usersService.findAll();
   }


### PR DESCRIPTION
Instead of protecting single mutation in a user resolver added admin auth guard in the mutation level